### PR TITLE
Changed this.props.store.dispatch to this.props.dispatch in App.js and README.md to resolve undefined error

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import './App.css';
+
+
+class App extends Component {
+
+  handleOnClickItems() {
+    this.props.dispatch({
+      type: 'GET_COUNT_OF_ITEMS',
+    });
+  }
+
+  handleOnClickUsers() {
+    this.props.dispatch({
+      type: 'GET_COUNT_OF_USERS',
+    });
+  }
+
+  render() {
+    // debugger;
+    return (
+      <div className="App">
+          <button onClick={() => this.handleOnClickItems()}>
+            Click to change items count
+            </button>
+          <button onClick={() => this.handleOnClickUsers()}>
+            Click to change user count
+          </button>
+          <p>{this.props.items.length}</p>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => {
+  debugger;
+  return { items: state.items }
+}
+
+export default connect(mapStateToProps)(App);

--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ import './App.css';
 class App extends Component {
 
   handleOnClickItems() {
-    this.props.store.dispatch({
+    this.props.dispatch({
       type: 'GET_COUNT_OF_ITEMS',
     });
   }
 
   handleOnClickUsers() {
-    this.props.store.dispatch({
+    this.props.dispatch({
       type: 'GET_COUNT_OF_USERS',
     })
   }


### PR DESCRIPTION
Students were receiving this error: 
```
TypeError: Cannot read property 'dispatch' of undefined
App.handleOnClickUsers
src/App.js:15
  12 | }
  13 | 
  14 | handleOnClickUsers() {
> 15 |   this.props.store.dispatch({
  16 |     type: 'GET_COUNT_OF_USERS',
  17 |   });
  18 | }
```

when using `this.props.store.dispatch`. `this.props.dispatch` solves the issue